### PR TITLE
🔥APIのリクエスト先を変更いたしましたわ～～💯

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> ExitCode {
 
     let client = reqwest::Client::new();
     let res = client
-        .post("https://ojosama.herokuapp.com/api/ojosama")
+        .post("https://api.ojosama.jiro4989.com")
         .json(&post_body)
         .send()
         .await


### PR DESCRIPTION
## 変更内容

- API リクエスト先を新ドメインに変更しました

## 背景

ojosama の Web API は Heroku の無料枠で動かしているのですが、[Heroku無料プランの廃止](https://blog.heroku.com/next-chapter)が公式発表されました。
これに伴い、実行基盤を Heroku から AWS に変更することにしました。

基盤の変更に合わせて Web API のドメインも変更することにしましたので、
リクエスト先を新ドメインに変更します。

すでに新ドメインで API を使えるようにしているため、以下のコマンドで動作確認できます。
初回リクエスト時はやや時間がかかりますが、結果が返ってくるはずです。

```bash
curl -X POST -H 'Content-Type: application/json' -d '{"Text":"これはハーブです！"}' https://api.ojosama.jiro4989.com
```

旧ドメインの方は2022年10月中のどこかのタイミングで使えなくする予定です。

## 関連

https://github.com/jiro4989/ojosama-web/issues/23